### PR TITLE
members/admin.py: prevent KeyError

### DIFF
--- a/members/admin.py
+++ b/members/admin.py
@@ -343,7 +343,8 @@ class PersonAdmin(admin.ModelAdmin):
             membership_request = MembershipRequest.objects.get(pk=key)
             self.populate_form_from_membership_request(form, membership_request)
         # Enforce uniqueness in Django, and not at database level, for backwards compatibility
-        form.base_fields['person_id'].validators.append(partial(Person.validate_person_id_unique, id=obj.id if obj else None))
+        if 'person_id' in form.base_fields:
+            form.base_fields['person_id'].validators.append(partial(Person.validate_person_id_unique, id=obj.id if obj else None))
         return form
 
     def save_model(self, request, obj, form, change):


### PR DESCRIPTION
I think the KeyError triggers when someone with only view permssions visits this admin page.